### PR TITLE
Possibly fixed async issue with tasks hanging on Minecraft server restarts.

### DIFF
--- a/diocraft/cogs/main_cog.py
+++ b/diocraft/cogs/main_cog.py
@@ -15,10 +15,11 @@ class MainCog(commands.Cog, name = "main"):
         super().__init__()
 
         self.mcr = MCRcon(server_ip, server_password, int(server_port))
+
         try:
             self.mcr.connect()
-        except:
-            print("Unexpected error: {}".format(sys.exc_info()[0]))
+        finally:
+            self.mcr.disconnect()
 
         self.bot = bot
 

--- a/diocraft/diocraft.py
+++ b/diocraft/diocraft.py
@@ -16,3 +16,5 @@ class DioCraft(commands.Bot):
 
     async def on_ready(self):
         print("Bot is ready!")
+        channel = self.get_channel(729513577186066473)
+        await channel.send("I have just started up. Please connect me by typing /login.")


### PR DESCRIPTION
- If the Minecraft server restarted then the bot would no longer respond. The bot's async thread would stop running. Possibly fixed by using a "Try Finally" to disconnect the bot if the server is down.
- Requires manual login at the start and any time it gets disconnected.