### PR TITLE
ACTUALLY* Fixed async hanging on Minecraft Server restart.

### DIFF
--- a/diocraft/cogs/main_cog.py
+++ b/diocraft/cogs/main_cog.py
@@ -18,7 +18,8 @@ class MainCog(commands.Cog, name = "main"):
 
         try:
             self.mcr.connect()
-        finally:
+        except:
+            print("Unexpected error: {}".format(sys.exc_info()[0]))
             self.mcr.disconnect()
 
         self.bot = bot
@@ -33,6 +34,7 @@ class MainCog(commands.Cog, name = "main"):
                 await channel.send("Successfully logged into the Minecraft server.")
             except:
                 await channel.send("Unexpected error: {}".format(sys.exc_info()[0]))
+                self.mcr.disconnect()
 
     @commands.command()
     async def awl(self, ctx: commands.Command):

--- a/diocraft/diocraft.py
+++ b/diocraft/diocraft.py
@@ -17,4 +17,4 @@ class DioCraft(commands.Bot):
     async def on_ready(self):
         print("Bot is ready!")
         channel = self.get_channel(729513577186066473)
-        await channel.send("I have just started up. Please connect me by typing /login.")
+        await channel.send("Oh? You're Launching Me?")


### PR DESCRIPTION
- In the except for the initialization of MainCog and the Login to RCON function, the connection was never closed if the server was restarted so the async thread was hanging. This has now been fixed.