### PR TITLE
Reverting discord.py version specification.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-discord==1.3.4
+discord
 python-dotenv
 mcrcon


### PR DESCRIPTION
- Version specification of 1.3.4 for discord.py did not make a difference on Heroku. Version issue is still persistent.